### PR TITLE
예외처리 개발

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-	runtimeOnly("com.mysql:mysql-connector-java")
+	runtimeOnly("mysql:mysql-connector-java")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")
 	implementation("org.springframework.boot:spring-boot-starter-mail")

--- a/src/main/kotlin/com/aeyoung/together/domain/member/exception/DuplicatedEmailException.kt
+++ b/src/main/kotlin/com/aeyoung/together/domain/member/exception/DuplicatedEmailException.kt
@@ -1,0 +1,6 @@
+package com.aeyoung.together.domain.member.exception
+
+import com.aeyoung.together.global.exception.BasicException
+import com.aeyoung.together.global.exception.ErrorCode
+
+class DuplicatedEmailException : BasicException(ErrorCode.DUPLICATE_EMAIL)

--- a/src/main/kotlin/com/aeyoung/together/domain/member/presentation/controller/AuthController.kt
+++ b/src/main/kotlin/com/aeyoung/together/domain/member/presentation/controller/AuthController.kt
@@ -1,7 +1,7 @@
-package com.aeyoung.together.domain.member.controller
+package com.aeyoung.together.domain.member.presentation.controller
 
-import com.aeyoung.together.domain.member.dto.req.MemberSignUpReqDto
-import com.aeyoung.together.domain.member.service.req.MemberSignUpService
+import com.aeyoung.together.domain.member.presentation.dto.req.MemberSignUpReqDto
+import com.aeyoung.together.domain.member.service.MemberSignUpService
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -10,12 +10,12 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/members")
+@RequestMapping("/auth")
 class AuthController(
         private val memberSignUpService: MemberSignUpService
 ) {
 
-    @PostMapping("/signup")
+    @PostMapping
     fun signUp(@Valid @RequestBody member: MemberSignUpReqDto): ResponseEntity<Void> {
         memberSignUpService.join(member)
         return ResponseEntity.ok().build();

--- a/src/main/kotlin/com/aeyoung/together/domain/member/presentation/dto/req/MemberSignUpReqDto.kt
+++ b/src/main/kotlin/com/aeyoung/together/domain/member/presentation/dto/req/MemberSignUpReqDto.kt
@@ -1,4 +1,4 @@
-package com.aeyoung.together.domain.member.dto.req
+package com.aeyoung.together.domain.member.presentation.dto.req
 
 import com.aeyoung.together.domain.member.Member
 import com.aeyoung.together.domain.member.Role

--- a/src/main/kotlin/com/aeyoung/together/domain/member/service/MemberSignUpService.kt
+++ b/src/main/kotlin/com/aeyoung/together/domain/member/service/MemberSignUpService.kt
@@ -1,6 +1,6 @@
-package com.aeyoung.together.domain.member.service.req
+package com.aeyoung.together.domain.member.service
 
-import com.aeyoung.together.domain.member.dto.req.MemberSignUpReqDto
+import com.aeyoung.together.domain.member.presentation.dto.req.MemberSignUpReqDto
 import org.springframework.stereotype.Service
 
 @Service

--- a/src/main/kotlin/com/aeyoung/together/domain/member/service/impl/MemberSignUpServiceImpl.kt
+++ b/src/main/kotlin/com/aeyoung/together/domain/member/service/impl/MemberSignUpServiceImpl.kt
@@ -1,10 +1,9 @@
-package com.aeyoung.together.domain.member.service.impl.req
+package com.aeyoung.together.domain.member.service.impl
 
-import com.aeyoung.together.domain.member.dto.req.MemberSignUpReqDto
+import com.aeyoung.together.domain.member.presentation.dto.req.MemberSignUpReqDto
 import com.aeyoung.together.domain.member.repository.MemberRepository
-import com.aeyoung.together.domain.member.service.req.MemberSignUpService
-import com.aeyoung.together.global.exception.DuplicatedEmailException
-import com.aeyoung.together.global.exception.ErrorCode
+import com.aeyoung.together.domain.member.service.MemberSignUpService
+import com.aeyoung.together.domain.member.exception.DuplicatedEmailException
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 
@@ -15,11 +14,10 @@ class MemberSignUpServiceImpl(
 ) : MemberSignUpService {
 
     override fun join(
-            memberSignUpReqDto: MemberSignUpReqDto,
+        memberSignUpReqDto: MemberSignUpReqDto,
     ): Long {
-        if (memberRepository.existsByEmail(memberSignUpReqDto.email)) {
-            throw DuplicatedEmailException(ErrorCode.DUPLICATE_EMAIL)
-        }
+        if (memberRepository.existsByEmail(memberSignUpReqDto.email))
+            throw DuplicatedEmailException()
         val member = memberSignUpReqDto.toEntity(passwordEncoder.encode(memberSignUpReqDto.password));
         return memberRepository.save(member).id
     }

--- a/src/main/kotlin/com/aeyoung/together/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/aeyoung/together/global/config/security/SecurityConfig.kt
@@ -33,6 +33,9 @@ class SecurityConfig(
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
             .authorizeHttpRequests()
+
+            .requestMatchers("/auth/**").permitAll()
+
             .requestMatchers("/**").denyAll()
             .and()
             .exceptionHandling()

--- a/src/main/kotlin/com/aeyoung/together/global/exception/DuplicatedEmailException.kt
+++ b/src/main/kotlin/com/aeyoung/together/global/exception/DuplicatedEmailException.kt
@@ -1,3 +1,0 @@
-package com.aeyoung.together.global.exception
-
-open class DuplicatedEmailException(val errorCode: ErrorCode) : RuntimeException(errorCode.msg)

--- a/src/main/kotlin/com/aeyoung/together/global/exception/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/aeyoung/together/global/exception/handler/GlobalExceptionHandler.kt
@@ -1,0 +1,35 @@
+package com.aeyoung.together.global.exception.handler
+
+import com.aeyoung.together.global.exception.BasicException
+import com.aeyoung.together.global.exception.ErrorResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.BindException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler{
+    private val log = LoggerFactory.getLogger(this::class.simpleName)
+
+    @ExceptionHandler(BasicException::class)
+    fun basicExceptionHandling(req: HttpServletRequest, res: HttpServletResponse, ex: BasicException): ErrorResponse{
+        log.error(req.requestURI)
+        log.error(ex.errorCode.msg)
+        return ErrorResponse(ex.errorCode)
+    }
+
+    @ExceptionHandler(BindException::class)
+    fun bindExceptionHandler(req: HttpServletRequest, ex: BindException): ResponseEntity<*> {
+        log.error(req.requestURI)
+        log.error(ex.message)
+        val errorMap: MutableMap<String, String?> = HashMap()
+        for (error in ex.fieldErrors) {
+            errorMap[error.field] = error.defaultMessage
+        }
+        return ResponseEntity<Map<String, String?>>(errorMap, HttpStatus.BAD_REQUEST)
+    }
+}


### PR DESCRIPTION
## 🗃️ 개요
* exception핸들링 개발
* 개발하다가  [저번pr](https://github.com/AEYung/Together-server/pull/4)에서 반영안된 부분과 기타 부분을 수정했습니다.

## 📜 작업내용
* exceptionHandler개발
* controller와 dto를 presentation 패키지에 묶음
* 얘외를 특정도메인/exception 에서 exception목록을 모아놓게 변경
* 회원가입은 ```[POST]/members/signup``` 보단 ```[POST]/auth``` 가 더 restful할거 같아서 변경
* 그리고 /members/** 는 인증되고 유저의 정보를 가져올때 사용하는게 좋을거 같아서 수정
* service에 req있던 패키지 제거

## 🔄 변경사항
* 기존의 /members/signup을 /auth로 변경했습니다.
* 기존에 /global/exception에 모외놨던 예외를 특정도메인/exception에 모아놓게 변경했습니다.

## 🎸 기타
#6 
* 앞으로 예외만들땐 BasicException을 상속받아서 특정도메인/exception에 만들어주세요.
* 원래 한 pr에서 저렇게 많이 작업하면 안되는데 이번엔 이렇게 했습니다.
